### PR TITLE
Change to the git clone step to use git's -C flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ $ wget https://raw.githubusercontent.com/frgomes/bash-scripts/master/postinstall
 This is how I install these scripts in my environment:
 
 ```bash
-$ mkdir $HOME/workspace && cd $HOME/workspace
-$ git clone http://github.com/frgomes/bash-scripts
+$ mkdir -p "$HOME/workspace"
+$ git -C  "$HOME/workspace/bash-scripts" clone http://github.com/frgomes/bash-scripts
 ```
 
 Then add a call to ``$HOME/workspace/bash-scripts/bashrc`` into your ``$HOME/.bashrc``:


### PR DESCRIPTION
Loving the repo! I've only scratched the surface on your scripts but I look forward to getting into it more.

I included a trick I use in my own scripts, which is using `git -C` to choose the working directory for the git operation (e.g. `git clone`). That way you can remove a `cd`. Not a huge deal, but I thought you might appreciate it; I did not learn about `git -C` until relatively recently.

Apologies for any mistakes on my end; I'm a PR novice. Thanks & be well!